### PR TITLE
LogRhythm service improvements and agent fixes

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,10 +4,10 @@ class ss_logrhythm::client (
   Stdlib::Compat::Ip_address  $agent_ip,          # Platform agent server ip to forward syslog messages to
   Integer                     $agent_port = 514,  # Platform agent server port to forward syslog messages to
   Boolean                     $enabled = true,     # Enable client config by default
+  String                      $rsyslog_delivery = "@${agent_ip}:${agent_port}",
 ) inherits ss_logrhythm {
   if $enabled == true {
     $logrhythm_agent_ensure = present
-    $rsyslog_delivery = "@${agent_ip}:${agent_port}"
   } else {
     $logrhythm_agent_ensure = absent
   }

--- a/manifests/kinesis.pp
+++ b/manifests/kinesis.pp
@@ -1,29 +1,15 @@
 # Setup LogRhythm client
 # Client forwards rsyslog logs to agent server
 class ss_logrhythm::kinesis (
-  Boolean $enabled = true, # Enable client config by default
-  Variant[Stdlib::HTTPSUrl,Stdlib::HttpUrl] $package_url = '', # eg. https://s3-ap-southeast-2.amazonaws.com/ss-packages/logrhythm/aws-kinesis-agent_0.9-Ubuntu_amd64.deb
+  Boolean                                   $enabled = true, # Enable client config by default
+  Variant[Stdlib::HTTPSUrl,Stdlib::HttpUrl] $package_url,    # eg. https://s3-ap-southeast-2.amazonaws.com/ss-packages/logrhythm/aws-kinesis-agent_0.9-Ubuntu_amd64.deb
 ) inherits ss_logrhythm {
-
   require java
 
   # Set up rsyslog configuration
-  if $enabled == true {
-    $logrhythm_agent_ensure = present
-    $rsyslog_delivery = "    *.* /var/log/kinesis/logrhythm.log\n    \$FileCreateMode 0644"
-  } else {
-    $logrhythm_agent_ensure = absent
-  }
-
-  # Add logryhthm rsyslog configuration
-  file {'logrhythm_syslog.conf':
-    ensure  => $logrhythm_agent_ensure,
-    path    => '/etc/rsyslog.d/logrhythm.conf',
-    content => template('ss_logrhythm/rsyslogd_client.conf.erb'),
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    notify  => Service['rsyslog'],
+  class {'ss_logrhythm::client':
+    agent_ip         => '127.0.0.1', # Dummy Agent IP
+    rsyslog_delivery => "    *.* /var/log/kinesis/logrhythm.log\n    \$FileCreateMode 0644"
   }
 
   # install Kinesis from .deb - package name is the last part dof agent URL
@@ -40,16 +26,10 @@ class ss_logrhythm::kinesis (
     ensure   => installed,
     provider => dpkg,
     source   => "/usr/src/${kinesis_package}"
-  }-> file { 'agent.json':
-    path    => '/etc/aws-kinesis-agent/agent.json',
-    content => template('ss_logrhythm/kinesis-agent.json.erb'),
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    require => Package['aws-kinesis-agent'],
-  }-> service {'aws-kinesis-agent':
+  }
+  
+  service {'aws-kinesis-agent':
     ensure    => running,
-    enable    => true,
-    subscribe => File['agent.json'],
+    enable    => true
   }
 }

--- a/templates/kinesis-agent.json.erb
+++ b/templates/kinesis-agent.json.erb
@@ -1,1 +1,0 @@
-<%# Mock empty agent.json in case file managed by puppet in future -%>


### PR DESCRIPTION
Changes:
 - Moved `$rsyslog_delivery` variable to Class Parameters in `Client.pp` allowing `Kinesis.pp` to use this class for configuration.
 - Update `Kinesis.pp` to use `ss_logrhythm::client` class for Rsyslog configuration
 - Removed `agent.json` configuration as the default settings allow service to run
 >Configuration of agent.json should be done on release instead - As variables containing the data for this are only available on the stack.