### PR TITLE
Create /opt directory for Kinesis Agent checkpoint data

### DIFF
--- a/manifests/kinesis.pp
+++ b/manifests/kinesis.pp
@@ -7,6 +7,20 @@ class ss_logrhythm::kinesis (
 
   require java
 
+  # Ubuntu resets permissions/access to /var/run folders on reboot.
+  # So we use a custom directory for storing agent checkpoint data
+  file { '/opt/aws-kinesis-agent':
+    ensure => 'directory',
+    owner => 'aws-kinesis-agent-user',
+    group => 'aws-kinesis-agent-user',
+    mode  => '0644',
+  }-> file { '/opt/aws-kinesis-agent/run':
+    ensure => 'directory',
+    owner => 'aws-kinesis-agent-user',
+    group => 'aws-kinesis-agent-user',
+    mode  => '0644',
+  }
+
   # Set up rsyslog configuration
   file { '/var/log/kinesis':
     ensure => 'directory',


### PR DESCRIPTION
Kinesis agent by default attempts to write checkpoint data to /var/run/aws-kinesis directory. However Ubuntu changes permissions on these folders at boot preventing the application from writing to it.

The following changes have been made to move the checkpoint storage location to `/opt` and ensure correct permissions are used.

This configuration is set in `agent.json`via https://code.silverstripe.cloud/aws/aws-projects/-/merge_requests/900/diffs#a5abb4cc071d82f3699ed6c92d130e59abf74da7_45_24