### PR TITLE
Fix vector to 0.20.0

### DIFF
--- a/manifests/vector.pp
+++ b/manifests/vector.pp
@@ -23,7 +23,7 @@ class ss_logrhythm::vector (
 
   # Install Vector package
   package { 'vector': 
-    ensure => 'present',
+    ensure => '0.20.0',
   }
 
   Class['apt::update'] -> Package['vector']


### PR DESCRIPTION
Fix for vector as 'ndjson' format for kinesis broken in later releases which breaks integration with LogRhythm (as logrhythm expects new-line delimeted JSON).